### PR TITLE
use maphash instead of xxhash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/stealthrocket/wzprof
 go 1.20
 
 require (
-	github.com/cespare/xxhash v1.1.0
 	github.com/google/pprof v0.0.0-20230406165453-00490a63f317
 	github.com/tetratelabs/wazero v1.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,5 @@
-github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
-github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
-github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/google/pprof v0.0.0-20230406165453-00490a63f317 h1:hFhpt7CTmR3DX+b4R19ydQFtofxT0Sv3QsKNMVQYTMQ=
 github.com/google/pprof v0.0.0-20230406165453-00490a63f317/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stealthrocket/wazero v0.0.0-20230430142342-055e238d3c28 h1:HAHxWh4xnTbdJllRWuAowcl+odny4oIxB8tGi1oHIGM=


### PR DESCRIPTION
This removes a dependency + we can use `WriteString` when hashing instead of causing a copy of the function name when converting from `string` to `[]byte`.