### PR TITLE
cleanup: pass profile.ValueType by pointer

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -51,8 +51,8 @@ func (p *ProfilerCPU) Listen(name string) string {
 	return "count1"
 }
 
-func (p *ProfilerCPU) SampleType() profile.ValueType {
-	return profile.ValueType{Type: "cpu_samples", Unit: "count"}
+func (p *ProfilerCPU) SampleType() *profile.ValueType {
+	return &profile.ValueType{Type: "cpu_samples", Unit: "count"}
 }
 
 func (p *ProfilerCPU) Sampler() Sampler {

--- a/cputime.go
+++ b/cputime.go
@@ -55,8 +55,8 @@ func (p *ProfilerCPUTime) Listen(name string) string {
 	return "time"
 }
 
-func (p *ProfilerCPUTime) SampleType() profile.ValueType {
-	return profile.ValueType{Type: "cpu_time", Unit: "nanosecond"}
+func (p *ProfilerCPUTime) SampleType() *profile.ValueType {
+	return &profile.ValueType{Type: "cpu_time", Unit: "nanosecond"}
 }
 
 func (p *ProfilerCPUTime) Sampler() Sampler {

--- a/mem.go
+++ b/mem.go
@@ -108,8 +108,8 @@ func (p *ProfilerMemory) Listen(name string) string {
 	}
 }
 
-func (p *ProfilerMemory) SampleType() profile.ValueType {
-	return profile.ValueType{Type: "alloc_space", Unit: "bytes"}
+func (p *ProfilerMemory) SampleType() *profile.ValueType {
+	return &profile.ValueType{Type: "alloc_space", Unit: "bytes"}
 }
 
 func (p *ProfilerMemory) Sampler() Sampler {

--- a/profiler.go
+++ b/profiler.go
@@ -49,7 +49,7 @@ type ProfileProcessor interface {
 type Profiler interface {
 	// SampleType is called once initially to register the pprof type of
 	// samples collected by this profiler. Only one type permitted for now.
-	SampleType() profile.ValueType
+	SampleType() *profile.ValueType
 
 	// Sampler is called once initially to register which sampler to use for
 	// this profiler.
@@ -203,8 +203,7 @@ func (p *ProfilerListener) BuildProfile() *profile.Profile {
 	}
 
 	for _, p := range p.profilers {
-		t := p.SampleType()
-		prof.SampleType = append(prof.SampleType, &t)
+		prof.SampleType = append(prof.SampleType, p.SampleType())
 	}
 
 	counters := make(map[uint64]*profile.Sample)


### PR DESCRIPTION
It seems that the intent was for these values to be referenced by pointer in pprof (for example https://pkg.go.dev/github.com/google/pprof/profile#Profile), let's follow the model.