### PR TITLE
cleanup: remove TODO about using string builder

### DIFF
--- a/dwarf.go
+++ b/dwarf.go
@@ -153,10 +153,9 @@ func (d *dwarfparser) parseAny(cu *dwarf.Entry, ns string, e *dwarf.Entry) {
 func (d *dwarfparser) parseNamespace(cu *dwarf.Entry, ns string, e *dwarf.Entry) {
 	// Assumption is that r has just read the top level entry of this
 	// namespace, which is e.
-
 	name, ok := e.Val(dwarf.AttrName).(string)
 	if ok {
-		ns += name + ":" // TODO: string builder.
+		ns += name + ":"
 	}
 	d.parseCompileUnit(cu, ns)
 }


### PR DESCRIPTION
This TODO seems unnecessary; a string builder isn't going to optimize the concatenation in this case, the compiler can generate optimal code to minimize heap allocations and memory copies.