### PR TITLE
optimize critical section of CPU profiler

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -202,24 +202,22 @@ func (p cpuListener) Before(ctx context.Context, mod api.Module, def api.Functio
 		}
 	}
 
-	p.frames = append(p.frames, frame)
 	p.mutex.Unlock()
+	p.frames = append(p.frames, frame)
 	return ctx
 }
 
 func (p cpuListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, results []uint64) {
-	p.mutex.Lock()
-
 	i := len(p.frames) - 1
 	f := p.frames[i]
 	p.frames = p.frames[:i]
 
 	if f.start != 0 {
+		p.mutex.Lock()
 		if p.counts != nil {
 			p.counts.observe(f.trace, p.time()-f.start)
 		}
+		p.mutex.Unlock()
 		p.traces = append(p.traces, f.trace)
 	}
-
-	p.mutex.Unlock()
 }

--- a/cpu_test.go
+++ b/cpu_test.go
@@ -4,8 +4,13 @@ import (
 	"testing"
 )
 
-func BenchmarkCPUProfiler(b *testing.B) {
+func BenchmarkCPUProfilerOn(b *testing.B) {
 	p := NewCPUProfiler()
 	p.StartProfile()
+	benchmarkFunctionListener(b, p)
+}
+
+func BenchmarkCPUProfilerOff(b *testing.B) {
+	p := NewCPUProfiler()
 	benchmarkFunctionListener(b, p)
 }


### PR DESCRIPTION
This PR modifies the CPU profiler to only take a lock when it's needed.