### PR TITLE
match the pprof output

### DIFF
--- a/cmd/wzprof/main_test.go
+++ b/cmd/wzprof/main_test.go
@@ -18,7 +18,7 @@ import (
 func TestDataCSimple(t *testing.T) {
 	testMemoryProfiler(t, "../../testdata/c/simple.wasm", []sample{
 		{
-			[]int64{10, 1},
+			[]int64{1, 10},
 			[]frame{
 				{"malloc", 0, false},
 				{"func1", 6, false},
@@ -28,7 +28,7 @@ func TestDataCSimple(t *testing.T) {
 			},
 		},
 		{
-			[]int64{20, 1},
+			[]int64{1, 20},
 			[]frame{
 				{"malloc", 0, false},
 				{"func21", 12, false},
@@ -39,7 +39,7 @@ func TestDataCSimple(t *testing.T) {
 			},
 		},
 		{
-			[]int64{30, 1},
+			[]int64{1, 30},
 			[]frame{
 				{"malloc", 0, false},
 				{"func31", 29, true},
@@ -55,7 +55,7 @@ func TestDataCSimple(t *testing.T) {
 func TestDataRustSimple(t *testing.T) {
 	testMemoryProfiler(t, "../../testdata/rust/simple/target/wasm32-wasi/debug/simple.wasm", []sample{
 		{
-			[]int64{120, 1},
+			[]int64{1, 120},
 			[]frame{
 				{"malloc", 0, false},                                                                        // malloc
 				{"std:sys:wasi:alloc:{impl#0}:alloc", 381, true},                                            // _ZN3std3sys4wasi5alloc81_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$5alloc17hf06d843ee28c936eE
@@ -115,10 +115,10 @@ func testMemoryProfiler(t *testing.T, path string, expectedSamples []sample) {
 	}
 
 	expectedTypes := []string{
-		"alloc_space",
 		"alloc_objects",
-		"inuse_space",
+		"alloc_space",
 		"inuse_objects",
+		"inuse_space",
 	}
 
 	if len(p.SampleType) != len(expectedTypes) {

--- a/cpu.go
+++ b/cpu.go
@@ -16,8 +16,8 @@ import (
 // samples of CPU time spent in functions of a WebAssembly module.
 //
 // The profiler generates samples of two types:
-// - "cpu" records the time spent in function calls (in nanoseconds).
 // - "sample" counts the number of function calls.
+// - "cpu" records the time spent in function calls (in nanoseconds).
 type CPUProfiler struct {
 	mutex  sync.Mutex
 	counts stackCounterMap
@@ -110,8 +110,8 @@ func (p *CPUProfiler) StopProfile(sampleRate float64, symbols Symbolizer) *profi
 
 	return buildProfile(sampleRate, symbols, samples, start, duration,
 		[]*profile.ValueType{
-			{Type: "cpu", Unit: "nanoseconds"},
 			{Type: "samples", Unit: "count"},
+			{Type: "cpu", Unit: "nanoseconds"},
 		},
 	)
 }

--- a/mem.go
+++ b/mem.go
@@ -59,17 +59,17 @@ func NewMemoryProfiler(opts ...MemoryProfilerOption) *MemoryProfiler {
 func (p *MemoryProfiler) NewProfile(sampleRate float64, symbols Symbolizer) *profile.Profile {
 	return buildProfile(sampleRate, symbols, p.snapshot(), p.start, time.Since(p.start),
 		[]*profile.ValueType{
-			{Type: "alloc_space", Unit: "byte"},
 			{Type: "alloc_objects", Unit: "count"},
-			{Type: "inuse_space", Unit: "byte"},
+			{Type: "alloc_space", Unit: "byte"},
 			{Type: "inuse_objects", Unit: "count"},
+			{Type: "inuse_space", Unit: "byte"},
 		},
 	)
 }
 
 type memorySample struct {
 	stack stackTrace
-	value [4]int64 // allocBytes, allocCount, inuseBytes, inuseCount
+	value [4]int64 // allocCount, allocBytes, inuseCount, inuseBytes
 }
 
 func (m *memorySample) sampleLocation() stackTrace {
@@ -96,14 +96,14 @@ func (p *MemoryProfiler) snapshot() map[uint64]*memorySample {
 			p = &memorySample{stack: alloc.stack}
 			samples[alloc.stack.key] = p
 		}
-		p.value[0] += alloc.total()
-		p.value[1] += alloc.count()
+		p.value[0] += alloc.count()
+		p.value[1] += alloc.total()
 	}
 
 	for _, inuse := range p.inuse {
 		p := samples[inuse.stack.key]
-		p.value[2] += int64(inuse.size)
-		p.value[3] += 1
+		p.value[2] += 1
+		p.value[3] += int64(inuse.size)
 	}
 
 	return samples

--- a/wzprof.go
+++ b/wzprof.go
@@ -139,27 +139,27 @@ func (scm stackCounterMap) observe(st stackTrace, val int64) {
 
 type stackCounter struct {
 	stack stackTrace
-	value [2]int64 // total, count
+	value [2]int64 // count, total
 }
 
 func (sc *stackCounter) observe(value int64) {
-	sc.value[0] += value
-	sc.value[1] += 1
-}
-
-func (sc *stackCounter) total() int64 {
-	return sc.value[0]
+	sc.value[0] += 1
+	sc.value[1] += value
 }
 
 func (sc *stackCounter) count() int64 {
+	return sc.value[0]
+}
+
+func (sc *stackCounter) total() int64 {
 	return sc.value[1]
 }
 
 func (sc *stackCounter) subtract(value int64) {
 	if total := sc.total(); total < value {
-		sc.value[0] = 0
+		sc.value[1] = 0
 	} else {
-		sc.value[0] -= value
+		sc.value[1] -= value
 	}
 }
 


### PR DESCRIPTION
`go tool pprof` will default to displaying the last samples, so this PR fixes the order of sample values in the profiles generated by `wzprof` to match those of `pprof`.