### PR TITLE
dwarf: relax required sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ application performance.
 
 - CPU: calls sampling and on-CPU time.
 - Memory: allocations (see below).
-- DWARF support (demangling, source-level profiling)
+- DWARF support (demangling, source-level profiling).
 - Integrated pprof server.
 - Library and CLI interfaces.
 

--- a/dwarf.go
+++ b/dwarf.go
@@ -56,23 +56,10 @@ func newDwarfmapper(sections []api.CustomSection) (*dwarfmapper, error) {
 		}
 	}
 
-	if info == nil {
-		return nil, fmt.Errorf("dwarf: missing section: .debug_info")
+	d, err := dwarf.New(abbrev, nil, nil, info, line, nil, ranges, str)
+	if err != nil {
+		return nil, fmt.Errorf("dwarf: %w", err)
 	}
-	if line == nil {
-		return nil, fmt.Errorf("dwarf: missing section: .debug_line")
-	}
-	if str == nil {
-		return nil, fmt.Errorf("dwarf: missing section: .debug_str")
-	}
-	if abbrev == nil {
-		return nil, fmt.Errorf("dwarf: missing section: .debug_abbrev")
-	}
-	if ranges == nil {
-		return nil, fmt.Errorf("dwarf: missing section: .debug_ranges")
-	}
-
-	d, _ := dwarf.New(abbrev, nil, nil, info, line, nil, ranges, str)
 
 	r := d.Reader()
 


### PR DESCRIPTION
Not all sections are required to successfully use DWARF. For example, gc doesn't need debug_str. Instead, only skip DWARF symbolizer if the format is actually invalid. cc @chriso 