### PR TITLE
Allow wzprof to run without dwarf

### DIFF
--- a/cmd/wzprof/main.go
+++ b/cmd/wzprof/main.go
@@ -85,7 +85,8 @@ func (prog *program) run(ctx context.Context) error {
 
 	symbols, err := wzprof.BuildDwarfSymbolizer(compiledModule)
 	if err != nil {
-		return fmt.Errorf("symbolizing wasm module: %w", err)
+		symbols = nil
+		log.Println("warning: symbolizing wasm module:", err)
 	}
 
 	if prog.pprofAddr != "" {


### PR DESCRIPTION
Regression from #46. By turning this error into a warning, we allow wzprof to be used on modules that don't have DWARF, such as those produced by golang/go, and still provide meaningful results (though laking line-level profiles, and source code display).

cc @codefromthecrypt