### PR TITLE
Use name of the wasm file as source map in profile

### DIFF
--- a/cmd/wzprof/main.go
+++ b/cmd/wzprof/main.go
@@ -124,7 +124,7 @@ func (prog *program) run(ctx context.Context) error {
 		defer func() {
 			p := cpu.StopProfile(prog.sampleRate, symbols)
 			if !prog.hostProfile {
-				writeProfile(prog.cpuProfile, p)
+				writeProfile(wasmName, prog.cpuProfile, p)
 			}
 		}()
 	}
@@ -133,7 +133,7 @@ func (prog *program) run(ctx context.Context) error {
 		defer func() {
 			p := mem.NewProfile(prog.sampleRate, symbols)
 			if !prog.hostProfile {
-				writeProfile(prog.memProfile, p)
+				writeProfile(wasmName, prog.memProfile, p)
 			}
 		}()
 	}
@@ -260,7 +260,9 @@ func writeHeapProfile(f *os.File) {
 	}
 }
 
-func writeProfile(path string, prof *profile.Profile) {
+func writeProfile(wasmName string, path string, prof *profile.Profile) {
+	m := &profile.Mapping{ID: 1, File: wasmName}
+	prof.Mapping = []*profile.Mapping{m}
 	if err := wzprof.WriteProfile(path, prof); err != nil {
 		log.Print("ERROR: writing profile:", err)
 	}


### PR DESCRIPTION
Fixes #76

This information doesn't seem needed when serving over HTTP (I don't see any log complaining), so I opted for updating the profile before writing it, instead of carrying around the wasm module name and updating the two code paths that result in buildProfile.

Example output:

```
wzprof -memprofile mem.pb.gz -sample 1.0 testdata/c/simple.wasm \
 && go tool pprof -top mem.pb.gz
start
func1 malloc(10): 0x11500
func21 malloc(20): 0x11510
func31 malloc(30): 0x11530
end
File: simple.wasm
Type: alloc_space
Time: May 19, 2023 at 9:22am (EDT)
Duration: 9.89ms, Total samples = 80B
Showing nodes accounting for 80B, 100% of 80B total
      flat  flat%   sum%        cum   cum%
       72B 90.00% 90.00%        72B 90.00%  malloc
        8B 10.00%   100%         8B 10.00%  calloc
         0     0%   100%        80B   100%  __main_void
         0     0%   100%        80B   100%  _start
         0     0%   100%        10B 12.50%  func1
         0     0%   100%        20B 25.00%  func2
         0     0%   100%        20B 25.00%  func21
         0     0%   100%        30B 37.50%  func3
         0     0%   100%        30B 37.50%  func31 (inline)
         0     0%   100%        60B 75.00%  main
```