### PR TITLE
add flagged function listener

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -10,7 +10,7 @@ import (
 
 // Flag returns a function listener factory which creates listeners where
 // calls to their Before/After methods are gated by the boolean flag pointed
-// at bythe first argument.
+// at by the first argument.
 //
 // The sampling mechanism is similar to the one implemented by Sample but it
 // gives the application control over when the listeners are enabled instead

--- a/sample_test.go
+++ b/sample_test.go
@@ -9,6 +9,54 @@ import (
 	"github.com/tetratelabs/wazero/experimental/wazerotest"
 )
 
+func TestFlaggedFunctionListener(t *testing.T) {
+	module := wazerotest.NewModule(nil,
+		wazerotest.NewFunction(func(ctx context.Context, mod api.Module) {}),
+	)
+
+	n := 0
+	f := func(context.Context, api.Module, api.FunctionDefinition, []uint64, experimental.StackIterator) { n++ }
+
+	flag := false
+
+	factory := Flag(&flag, experimental.FunctionListenerFactoryFunc(
+		func(def api.FunctionDefinition) experimental.FunctionListener {
+			return experimental.FunctionListenerFunc(f)
+		},
+	))
+
+	function := module.Function(0).Definition()
+	listener := factory.NewFunctionListener(function)
+	ctx := context.Background()
+
+	for i := 0; i < 20; i++ {
+		listener.Before(ctx, module, function, nil, nil)
+	}
+	if n != 0 {
+		t.Error("function listener called while the flag was set to false")
+	}
+
+	flag = true
+	for i := 0; i < 2; i++ {
+		listener.Before(ctx, module, function, nil, nil)
+	}
+	if n != 2 {
+		t.Errorf("wrong number of called to sampled listener: want=2 got=%d", n)
+	}
+
+	flag = false
+	for i := 0; i < 2; i++ {
+		listener.Before(ctx, module, function, nil, nil)
+	}
+	if n != 2 {
+		t.Errorf("wrong number of called to sampled listener: want=2 got=%d", n)
+	}
+
+	for i := 0; i < 24; i++ {
+		listener.After(ctx, module, function, nil)
+	}
+}
+
 func TestSampledFunctionListener(t *testing.T) {
 	module := wazerotest.NewModule(nil,
 		wazerotest.NewFunction(func(ctx context.Context, mod api.Module) {}),


### PR DESCRIPTION
This PR adds a new decorator of `experimental.FunctionListenerFactory` which enables/disables the listeners based on the state of a boolean value.