### PR TITLE
fix alloc unit

### DIFF
--- a/mem.go
+++ b/mem.go
@@ -96,7 +96,7 @@ func (p *MemoryProfiler) Count() int {
 func (p *MemoryProfiler) SampleType() []*profile.ValueType {
 	sampleType := []*profile.ValueType{
 		{Type: "alloc_objects", Unit: "count"},
-		{Type: "alloc_space", Unit: "byte"},
+		{Type: "alloc_space", Unit: "bytes"},
 	}
 
 	if p.inuse != nil {
@@ -105,7 +105,7 @@ func (p *MemoryProfiler) SampleType() []*profile.ValueType {
 		// sample values in buildProfile.
 		sampleType = append(sampleType,
 			&profile.ValueType{Type: "inuse_objects", Unit: "count"},
-			&profile.ValueType{Type: "inuse_space", Unit: "byte"},
+			&profile.ValueType{Type: "inuse_space", Unit: "bytes"},
 		)
 	}
 


### PR DESCRIPTION
Go uses `bytes` for the unit of `alloc_space`, see https://github.com/golang/go/blob/7ad92e95b56019083824492fbec5bb07926d8ebd/src/runtime/pprof/protomem.go#L20

Let's fix to stay as compatible as possible.