### PR TITLE
Build only for amd64|arm64 x linux|darwin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,12 @@ builds:
   - main: ./cmd/wzprof/main.go
     binary: wzprof
     mod_timestamp: '{{ .CommitTimestamp }}'
-
+    goarch:
+      - amd64
+      - arm64
+    goos:
+      - linux
+      - darwin
     ldflags:
       - -X main.version={{.Version}} 
 


### PR DESCRIPTION
Required since #85 is only compatible with this combination of OS and architecture.

goreleaser build with i386 and windows as well by default. 