### PR TITLE
Build on Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,9 +12,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    goos:
-      - linux
-      - darwin
     ldflags:
       - -X main.version={{.Version}} 
 

--- a/memory.go
+++ b/memory.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && (amd64 || arm64)
+//go:build amd64 || arm64
 
 package wzprof
 

--- a/pclntab.go
+++ b/pclntab.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"runtime"
 	"unsafe"
 
 	"github.com/tetratelabs/wazero"
@@ -163,9 +162,6 @@ func findStartOfModuleData(b, start, cutabaddr, filetabaddr []byte) int {
 type fid int
 
 func preparePclntabSymbolizer(wasmbin []byte, mod wazero.CompiledModule) (*pclntab, error) {
-	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
-		return nil, fmt.Errorf("pclntab only supported on linux and darwin")
-	}
 	data := wasmdataSection(wasmbin)
 	if data == nil {
 		return nil, fmt.Errorf("no data section in the wasm binary")

--- a/pclntab.go
+++ b/pclntab.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/tetratelabs/wazero"
@@ -162,6 +163,9 @@ func findStartOfModuleData(b, start, cutabaddr, filetabaddr []byte) int {
 type fid int
 
 func preparePclntabSymbolizer(wasmbin []byte, mod wazero.CompiledModule) (*pclntab, error) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		return nil, fmt.Errorf("pclntab only supported on linux and darwin")
+	}
 	data := wasmdataSection(wasmbin)
 	if data == nil {
 		return nil, fmt.Errorf("no data section in the wasm binary")


### PR DESCRIPTION
None of the code in this file seems Linux or macOS specific.

I just tried building this on Windows, and profiling SQLite on Windows, and it works fine.

If we want to restrict to the platforms wazero supports, this includes Windows and FreeBSD.