### PR TITLE
python support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,5 +63,8 @@ jobs:
         go-version-file: .go-version
         check-latest: true
 
+    - name: Setup python
+      run: make python
+
     - name: Test
-      run: make test
+      run: go test ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,4 +64,4 @@ jobs:
         check-latest: true
 
     - name: Test
-      run: go test -v ./...
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 testdata/rust/*/target/*
 testdata/.sysroot/*
 *.pb.gz
+.python

--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,17 @@ testdata.files = \
 	$(testdata.tinygo.wasm) \
 	$(testdata.wat.wasm)
 
+python.files = .python/python.wasm .python/python311.zip
+
 all: test
 
 clean:
-	rm -f $(testdata.files)
+	rm -f $(testdata.files) $(python.files)
 
 test: testdata
 	go test ./...
 
-testdata: wasi-libc $(testdata.files)
+testdata: wasi-libc python $(testdata.files)
 
 testdata/.sysroot:
 	mkdir -p testdata/.sysroot
@@ -53,6 +55,16 @@ testdata/wat/%.wasm: testdata/wat/%.wat
 	wat2wasm -o $@ $<
 
 wasi-libc: testdata/.sysroot/lib/wasm32-wasi/libc.a
+
+python: $(python.files)
+
+.python/python.wasm:
+	mkdir -p $(dir $@)
+	curl -fsSL https://timecraft.s3.amazonaws.com/python-vanilla/main/python.wasm -o $@
+
+.python/python311.zip:
+	mkdir -p $(dir $@)
+	curl -fsSL https://timecraft.s3.amazonaws.com/python-vanilla/main/python311.zip -o $@
 
 .gitmodules:
 	git submodule add --name wasi-libc -- \

--- a/README.md
+++ b/README.md
@@ -186,6 +186,38 @@ The CPU time profiler measures the actual time spent on-CPU without taking into
 account the off-CPU time (e.g waiting for I/O). For this profiler, all the
 host-functions are considered off-CPU.
 
+## Language support
+
+wzprof runs some heuristics to assess what the guest module is running to adapt
+the way it symbolizes and walks the stack. In all other cases, it defaults to
+inspecting the wasm stack and uses DWARF information if present in the module.
+
+### Golang
+
+If the guest has been compiled by golang/go 1.21+, wzprof inspects the memory
+to walk the Go stack, which provides full call stacks, instead of the shortened
+versions you would get without this support.
+
+In addition, wzprof parses pclntab to perform symbolization. This is the same
+mechanism the Go runtime itself uses to display meaningful stack traces when a
+panic occurs.
+
+### Python 3.11
+
+If the guest is CPython 3.11 and has been compiled with debug symbols (such as
+[timecraft's][timecraft-python]), wzprof walks the Python interpreter call
+stack, not the C stack it would otherwise report. This provides more meaningful
+profiling information on the script being executed.
+
+At the moment it does not support merging the C extension calls into the Python
+interpreter stack.
+
+Note that a current limitation of the implementation is that unloading or
+reloading modules may result in an incorrect profile. If that's a problem for
+you please file an issue in the github tracker.
+
+[timecraft-python]: https://docs.timecraft.dev/getting-started/prep-application/compiling-python#preparing-python
+
 ## Contributing
 
 Pull requests are welcome! Anything that is not a simple fix would probably

--- a/cmd/wzprof/main_test.go
+++ b/cmd/wzprof/main_test.go
@@ -16,7 +16,8 @@ import (
 // that.
 
 func TestDataCSimple(t *testing.T) {
-	testMemoryProfiler(t, "../../testdata/c/simple.wasm", []sample{
+	p := program{filePath: "../../testdata/c/simple.wasm"}
+	testMemoryProfiler(t, p, []sample{
 		{
 			[]int64{1, 10},
 			[]frame{
@@ -53,7 +54,8 @@ func TestDataCSimple(t *testing.T) {
 }
 
 func TestDataRustSimple(t *testing.T) {
-	testMemoryProfiler(t, "../../testdata/rust/simple/target/wasm32-wasi/debug/simple.wasm", []sample{
+	p := program{filePath: "../../testdata/rust/simple/target/wasm32-wasi/debug/simple.wasm"}
+	testMemoryProfiler(t, p, []sample{
 		{
 			[]int64{1, 120},
 			[]frame{
@@ -89,10 +91,51 @@ func TestDataRustSimple(t *testing.T) {
 	})
 }
 
-func TestGoTwoCalls(t *testing.T) {
-	wasm := "../../testdata/go/twocalls.wasm"
+func TestPyTwoCalls(t *testing.T) {
+	pyd := t.TempDir()
+	pyzip := filepath.Join(pyd, "/usr/local/lib/python311.zip")
+	pyscript := filepath.Join(pyd, "script.py")
+	os.MkdirAll(filepath.Dir(pyzip), os.ModePerm)
+	os.Link("../../.python/python311.zip", pyzip)
+	os.Link("../../testdata/python/simple.py", pyscript)
 
-	testCpuProfiler(t, wasm, []sample{
+	p := program{
+		filePath: "../../.python/python.wasm",
+		args:     []string{"/script.py"},
+		mounts:   []string{pyd + ":/"},
+	}
+
+	testCpuProfiler(t, p, []sample{
+		{ // deepest script.py call stack
+			[]int64{1},
+			[]frame{
+				{"script.a", 2, false},
+				{"script.b", 7, false},
+				{"script.c", 11, false},
+				{"script", 15, false},
+			},
+		},
+	})
+
+	testMemoryProfiler(t, p, []sample{
+		// byterray(100) allocates 28 bytes for the object, and 100+1 byte for
+		// the content because in python byte arrays are null-terminated.
+		{
+			[]int64{2, 129},
+			[]frame{
+				{"script.a", 3, false},
+				{"script.b", 7, false},
+				{"script.c", 11, false},
+				{"script", 15, false},
+			},
+		},
+	})
+}
+
+func TestGoTwoCalls(t *testing.T) {
+	p := program{filePath: "../../testdata/go/twocalls.wasm"}
+
+	testCpuProfiler(t, p, []sample{
 		{ // first call to myalloc1() from main.
 			[]int64{1},
 			[]frame{
@@ -129,7 +172,7 @@ func TestGoTwoCalls(t *testing.T) {
 		},
 	})
 
-	testMemoryProfiler(t, wasm, []sample{
+	testMemoryProfiler(t, p, []sample{
 		{ // first call to myalloc1() from main.
 			[]int64{1, 41},
 			[]frame{
@@ -167,35 +210,29 @@ func TestGoTwoCalls(t *testing.T) {
 	})
 }
 
-func testCpuProfiler(t *testing.T, path string, expectedSamples []sample) {
-	prog := &program{
-		filePath:   path,
-		sampleRate: 1,
-		cpuProfile: filepath.Join(t.TempDir(), "cpu.pprof"),
-	}
+func testCpuProfiler(t *testing.T, prog program, expectedSamples []sample) {
+	prog.sampleRate = 1
+	prog.cpuProfile = filepath.Join(t.TempDir(), "cpu.pprof")
 
 	expectedTypes := []string{
 		"samples",
 		"cpu",
 	}
 
-	p := execForProfile(t, prog, prog.cpuProfile)
+	p := execForProfile(t, &prog, prog.cpuProfile)
 	assertSamples(t, expectedTypes, expectedSamples, p)
 }
 
-func testMemoryProfiler(t *testing.T, path string, expectedSamples []sample) {
-	prog := &program{
-		filePath:   path,
-		sampleRate: 1,
-		memProfile: filepath.Join(t.TempDir(), "mem.pprof"),
-	}
+func testMemoryProfiler(t *testing.T, prog program, expectedSamples []sample) {
+	prog.sampleRate = 1
+	prog.memProfile = filepath.Join(t.TempDir(), "mem.pprof")
 
 	expectedTypes := []string{
 		"alloc_objects",
 		"alloc_space",
 	}
 
-	p := execForProfile(t, prog, prog.memProfile)
+	p := execForProfile(t, &prog, prog.memProfile)
 	assertSamples(t, expectedTypes, expectedSamples, p)
 }
 

--- a/cmd/wzprof/main_test.go
+++ b/cmd/wzprof/main_test.go
@@ -119,7 +119,8 @@ func TestPyTwoCalls(t *testing.T) {
 
 	testMemoryProfiler(t, p, []sample{
 		// byterray(100) allocates 28 bytes for the object, and 100+1 byte for
-		// the content because in python byte arrays are null-terminated.
+		// the content because in python byte arrays are null-terminated. It
+		// first calls PyObject_Malloc(28), then PyObject_Realloc(101).
 		{
 			[]int64{2, 129},
 			[]frame{

--- a/cpu.go
+++ b/cpu.go
@@ -204,10 +204,7 @@ func (p *CPUProfiler) NewFunctionListener(def api.FunctionDefinition) experiment
 
 type cpuProfiler struct{ *CPUProfiler }
 
-var mydepth = 0
-
 func (p cpuProfiler) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, _ []uint64, si experimental.StackIterator) {
-	mydepth++
 	var frame cpuTimeFrame
 	p.mutex.Lock()
 
@@ -232,7 +229,6 @@ func (p cpuProfiler) Before(ctx context.Context, mod api.Module, def api.Functio
 }
 
 func (p cpuProfiler) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, _ []uint64) {
-	mydepth--
 	i := len(p.frames) - 1
 	f := p.frames[i]
 	p.frames = p.frames[:i]

--- a/mem.go
+++ b/mem.go
@@ -178,6 +178,7 @@ func (p *MemoryProfiler) NewHandler(sampleRate float64) http.Handler {
 // compilers and libraries. It uses the function name to detect memory
 // allocators, currently supporting libc, Go, and TinyGo.
 func (p *MemoryProfiler) NewFunctionListener(def api.FunctionDefinition) experimental.FunctionListener {
+	return nil // TODO
 	switch def.Name() {
 	// C standard library, Rust
 	case "malloc":

--- a/mem.go
+++ b/mem.go
@@ -178,7 +178,7 @@ func (p *MemoryProfiler) NewHandler(sampleRate float64) http.Handler {
 // compilers and libraries. It uses the function name to detect memory
 // allocators, currently supporting libc, Go, and TinyGo.
 func (p *MemoryProfiler) NewFunctionListener(def api.FunctionDefinition) experimental.FunctionListener {
-	if p.p.isPython {
+	if p.p.lang == python311 {
 		switch def.Name() {
 		// Raw domain
 		case "PyMem_RawMalloc":

--- a/mem.go
+++ b/mem.go
@@ -178,7 +178,38 @@ func (p *MemoryProfiler) NewHandler(sampleRate float64) http.Handler {
 // compilers and libraries. It uses the function name to detect memory
 // allocators, currently supporting libc, Go, and TinyGo.
 func (p *MemoryProfiler) NewFunctionListener(def api.FunctionDefinition) experimental.FunctionListener {
-	return nil // TODO
+	if p.p.isPython {
+		switch def.Name() {
+		// Raw domain
+		case "PyMem_RawMalloc":
+			return profilingListener{p.p, &mallocProfiler{memory: p}}
+		case "PyMem_RawCalloc":
+			return profilingListener{p.p, &callocProfiler{memory: p}}
+		case "PyMem_RawRealloc":
+			return profilingListener{p.p, &reallocProfiler{memory: p}}
+		case "PyMem_RawFree":
+			return profilingListener{p.p, &freeProfiler{memory: p}}
+		// Memory domain
+		case "PyMem_Malloc":
+			return profilingListener{p.p, &mallocProfiler{memory: p}}
+		case "PyMem_Calloc":
+			return profilingListener{p.p, &callocProfiler{memory: p}}
+		case "PyMem_Realloc":
+			return profilingListener{p.p, &reallocProfiler{memory: p}}
+		case "PyMem_Free":
+			return profilingListener{p.p, &freeProfiler{memory: p}}
+		// Object domain
+		case "PyObject_Malloc":
+			return profilingListener{p.p, &mallocProfiler{memory: p}}
+		case "PyObject_Calloc":
+			return profilingListener{p.p, &callocProfiler{memory: p}}
+		case "PyObject_Realloc":
+			return profilingListener{p.p, &reallocProfiler{memory: p}}
+		case "PyObject_Free":
+			return profilingListener{p.p, &freeProfiler{memory: p}}
+		}
+		return nil
+	}
 	switch def.Name() {
 	// C standard library, Rust
 	case "malloc":

--- a/memory.go
+++ b/memory.go
@@ -8,10 +8,26 @@ import (
 	"unsafe"
 )
 
-// ptr represents an address in the guest memory. It replaces unintptr in the
-// original unwinder code. Here, the unwinder executes in the host, so this type
-// helps to avoid dereferencing the host memory.
-type ptr uint64
+// ptr64 represents a 64-bits address in the guest memory. It replaces unintptr
+// in the original unwinder code. Here, the unwinder executes in the host, so
+// this type helps to avoid dereferencing the host memory.
+type ptr64 uint64
+
+func (p ptr64) addr() uint32 {
+	return uint32(p)
+}
+
+// ptr32 represents a 32-bits address in the guest memory. It replaces pointers
+// in clang-wasi generated code.
+type ptr32 uint32
+
+func (p ptr32) addr() uint32 {
+	return uint32(p)
+}
+
+type ptr interface {
+	addr() uint32
+}
 
 // vmem is the minimum interface required for virtual memory accesses in this
 // package. Is is used to read guest memory and rebuild the constructs needed
@@ -26,6 +42,10 @@ type ptr uint64
 // uintptr/unsafe.Pointer are used to manipulate memory seen by the host, and
 // ptr is used to represent memory inside the guest.
 type vmem interface {
+	// Read returns a view of the size bytes at the given virtual
+	// address, or false if the requested bytes are out of range.
+	// Users of this output need not modify the bytes, and make a copy
+	// of them if they wish to persist the data.
 	Read(address, size uint32) ([]byte, bool)
 }
 
@@ -36,20 +56,37 @@ type vmem interface {
 func deref[T any](r vmem, p ptr) T {
 	var t T
 	s := uint32(unsafe.Sizeof(t))
-	b, ok := r.Read(uint32(p), s)
+	b, ok := r.Read(p.addr(), s)
 	if !ok {
 		panic(fmt.Errorf("invalid virtual memory read at %#x size %d", p, s))
 	}
 	return *(*T)(unsafe.Pointer((unsafe.SliceData(b))))
 }
 
+// derefArrayInto copies into the given host slice contiguous elements
+// of type T starting at the virtual address p to fill it.
+func derefArray[T any](r vmem, p ptr, n uint32) []T {
+	var t T
+	s := uint32(unsafe.Sizeof(t)) * n
+	view, ok := r.Read(p.addr(), s)
+	if !ok {
+		panic(fmt.Errorf("invalid virtual memory array read at %#x size %d", p, s))
+	}
+
+	outb := make([]byte, s)
+	copy(outb, view)
+	x := (*T)(unsafe.Pointer(unsafe.SliceData(outb)))
+	return unsafe.Slice(x, n)
+}
+
 // derefGoSlice takes a slice whose data pointer targets the guest memory, and
 // returns a copy the slice's contents in host memory. It is not recursive. Cap
-// is set to Len, no matter its initial value.
+// is set to Len, no matter its initial value. Assumes the underlying pointer is
+// 64-bits.
 func derefGoSlice[T any](r vmem, s []T) []T {
 	count := len(s)
 	sh := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-	dp := ptr(sh.Data)
+	dp := ptr64(sh.Data)
 	res := make([]T, count)
 	for i := 0; i < count; i++ {
 		res[i] = derefArrayIndex[T](r, dp, int32(i))
@@ -60,6 +97,7 @@ func derefGoSlice[T any](r vmem, s []T) []T {
 // Reads the i-th element of an array that starts at address p.
 func derefArrayIndex[T any](r vmem, p ptr, i int32) T {
 	var t T
-	s := ptr(unsafe.Sizeof(t))
-	return deref[T](r, p+ptr(i)*s)
+	a := p.addr()
+	s := uint32(unsafe.Sizeof(t))
+	return deref[T](r, ptr32(a+uint32(i)*s))
 }

--- a/python.go
+++ b/python.go
@@ -226,6 +226,9 @@ func functionName(path, function string) string {
 	if strings.HasPrefix(path, frozenPrefix) {
 		mod = path[len(frozenPrefix) : len(path)-1]
 	} else {
+		if strings.HasSuffix(path, "__init__.py") {
+			path = filepath.Dir(path)
+		}
 		file := filepath.Base(path)
 		mod = file[:len(file)-len(filepath.Ext(file))]
 	}

--- a/python.go
+++ b/python.go
@@ -118,18 +118,18 @@ func getDwarfLocationAddress(ent *dwarf.Entry) uint32 {
 // TODO: look into using CGO and #import<Python.h> to generate them
 // instead.
 const (
-	// _PyRuntimeState
+	// _PyRuntimeState.
 	padTstateCurrentInRT = 360
-	// PyThreadState
+	// PyThreadState.
 	padCframeInThreadState = 40
-	// _PyCFrame
+	// _PyCFrame.
 	padCurrentFrameInCFrame = 4
-	// _PyInterpreterFrame
+	// _PyInterpreterFrame.
 	padPreviousInFrame  = 24
 	padCodeInFrame      = 16
 	padPrevInstrInFrame = 28
 	padOwnerInFrame     = 37
-	// PyCodeObject
+	// PyCodeObject.
 	padFilenameInCodeObject       = 80
 	padNameInCodeObject           = 84
 	padCodeAdaptiveInCodeObject   = 116
@@ -138,14 +138,14 @@ const (
 	padLinetableInCodeObject      = 92
 	padFirstTraceableInCodeObject = 108
 	sizeCodeUnit                  = 2
-	// PyASCIIObject
+	// PyASCIIObject.
 	padStateInAsciiObject  = 16
 	padLengthInAsciiObject = 8
 	sizeAsciiObject        = 24
-	// PyBytesObject
+	// PyBytesObject.
 	padSvalInBytesObject = 16
 	padSizeInBytesObject = 8
-	// Enum constants
+	// Enum constants.
 	enumCodeLocation1         = 11
 	enumCodeLocation2         = 12
 	enumCodeLocationNoCol     = 13

--- a/python.go
+++ b/python.go
@@ -1,0 +1,368 @@
+package wzprof
+
+import (
+	"debug/dwarf"
+	"encoding/binary"
+	"fmt"
+	"unsafe"
+
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+)
+
+// Heuristic to guess whether the wasm binary is actually CPython, based on its
+// DWARF information.
+//
+// It loops over compile units to find one named "Programs/python.c". It should
+// be fast since it's the first compile unit when we build CPython.
+func guessPython(p dwarfparser) bool {
+	for {
+		ent, err := p.r.Next()
+		if err != nil || ent == nil {
+			break
+		}
+		if ent.Tag != dwarf.TagCompileUnit {
+			p.r.SkipChildren()
+			continue
+		}
+		name, _ := ent.Val(dwarf.AttrName).(string)
+		if name == "Programs/python.c" {
+			return true
+		}
+		p.r.SkipChildren()
+	}
+	return false
+}
+
+type python struct {
+	dwarf    dwarfparser
+	pyrtaddr ptr32
+
+	counter uint64
+}
+
+func preparePython(dwarf dwarfparser) (*python, error) {
+	pyrtaddr := findPyRuntime(dwarf)
+	if pyrtaddr == 0 {
+		return nil, fmt.Errorf("could not find _PyRuntime address")
+	}
+	return &python{
+		dwarf:    dwarf,
+		pyrtaddr: ptr32(pyrtaddr),
+	}, nil
+}
+
+// Find the address of the _PyRuntime symbol from the dwarf information.
+// Returns 0 if not found.
+func findPyRuntime(p dwarfparser) uint32 {
+	for {
+		ent, err := p.r.Next()
+		if err != nil || ent == nil {
+			break
+		}
+		if ent.Tag != dwarf.TagVariable {
+			continue
+		}
+		name, _ := ent.Val(dwarf.AttrName).(string)
+		if name != "_PyRuntime" {
+			continue
+		}
+		f := ent.AttrField(dwarf.AttrLocation)
+		if f == nil {
+			panic("_PyRuntime does not have a location")
+		}
+		if f.Class != dwarf.ClassExprLoc {
+			panic(fmt.Errorf("invalid location class: %s", f.Class))
+		}
+		const DW_OP_addr = 0x3
+		loc := f.Val.([]byte)
+		if len(loc) == 0 || loc[0] != DW_OP_addr {
+			panic(fmt.Errorf("unexpected address format: %X", loc))
+		}
+		return binary.LittleEndian.Uint32(loc[1:])
+	}
+	return 0
+}
+
+// Padding of fields in various CPython structs. They are calculated
+// by writing a function in any CPython module, and executing it with
+// wazero.
+//
+// TODO: look into using CGO and #import<Python.h> to generate them
+// instead.
+const (
+	// _PyRuntimeState
+	padTstateCurrentInRT = 360
+	// PyThreadState
+	padCframeInThreadState = 40
+	// _PyCFrame
+	padCurrentFrameInCFrame = 4
+	// _PyInterpreterFrame
+	padPreviousInFrame  = 24
+	padCodeInFrame      = 16
+	padPrevInstrInFrame = 28
+	padOwnerInFrame     = 37
+	// PyCodeObject
+	padFilenameInCodeObject       = 80
+	padNameInCodeObject           = 84
+	padCodeAdaptiveInCodeObject   = 116
+	padFirstlinenoInCodeObject    = 48
+	padLinearrayInCodeObject      = 104
+	padLinetableInCodeObject      = 92
+	padFirstTraceableInCodeObject = 108
+	sizeCodeUnit                  = 2
+	// PyASCIIObject
+	padStateInAsciiObject  = 16
+	padLengthInAsciiObject = 8
+	sizeAsciiObject        = 24
+	// PyBytesObject
+	padSvalInBytesObject = 16
+	padSizeInBytesObject = 8
+	// Enum constants
+	enumCodeLocation1         = 11
+	enumCodeLocation2         = 12
+	enumCodeLocationNoCol     = 13
+	enumCodeLocationLong      = 14
+	enumFrameOwnedByGenerator = 1
+)
+
+func (p *python) Locations(fn experimental.InternalFunction, pc experimental.ProgramCounter) (uint64, []location) {
+	call := fn.(pyfuncall)
+
+	loc := location{
+		File:       call.file,
+		Line:       int64(call.line),
+		HumanName:  call.name,
+		StableName: call.name,
+	}
+
+	return uint64(call.addr), []location{loc}
+}
+
+func (p *python) Stackiter(mod api.Module, def api.FunctionDefinition, wasmsi experimental.StackIterator) experimental.StackIterator {
+	m := mod.Memory()
+	tsp := deref[ptr32](m, p.pyrtaddr+padTstateCurrentInRT)
+	cframep := deref[ptr32](m, tsp+padCframeInThreadState)
+	framep := deref[ptr32](m, cframep+padCurrentFrameInCFrame)
+
+	return &pystackiter{
+		namedbg: def.DebugName(),
+		counter: &p.counter,
+		mem:     m,
+		framep:  framep,
+	}
+}
+
+type pystackiter struct {
+	namedbg string
+	counter *uint64
+	mem     api.Memory
+	started bool
+	framep  ptr32 // _PyInterpreterFrame*
+}
+
+func (p *pystackiter) Next() bool {
+	if !p.started {
+		p.started = true
+		return p.framep != 0
+	}
+
+	oldframe := p.framep
+	p.framep = deref[ptr32](p.mem, p.framep+padPreviousInFrame)
+	if oldframe == p.framep {
+		fmt.Printf("frame previous field pointer to the same frame: %x", p.framep)
+		p.framep = 0
+		return false
+	}
+	return p.framep != 0
+}
+
+func (p *pystackiter) ProgramCounter() experimental.ProgramCounter {
+	*p.counter += 1
+	return experimental.ProgramCounter(*p.counter)
+}
+
+func (p *pystackiter) Function() experimental.InternalFunction {
+	codep := deref[ptr32](p.mem, p.framep+padCodeInFrame)
+	return pyfuncall{
+		file: derefPyUnicodeUtf8(p.mem, codep+padFilenameInCodeObject),
+		name: derefPyUnicodeUtf8(p.mem, codep+padNameInCodeObject),
+		addr: deref[uint32](p.mem, p.framep+padPrevInstrInFrame),
+		line: lineForFrame(p.mem, p.framep, codep),
+	}
+}
+
+func (p *pystackiter) Parameters() []uint64 {
+	panic("TODO parameters()")
+}
+
+// pyfuncall represent a specific place in the python source where a
+// function call occurred.
+type pyfuncall struct {
+	file string
+	name string
+	line int32
+	addr uint32
+
+	api.FunctionDefinition // required for WazeroOnly
+}
+
+func (f pyfuncall) Definition() api.FunctionDefinition {
+	return f
+}
+
+func (f pyfuncall) SourceOffsetForPC(pc experimental.ProgramCounter) uint64 {
+	panic("does not make sense")
+}
+
+func (f pyfuncall) ModuleName() string {
+	return "<unknown>" // TODO
+}
+
+func (f pyfuncall) Index() uint32 {
+	return 42 // TODO
+}
+
+func (f pyfuncall) Import() (string, string, bool) {
+	panic("implement me")
+}
+
+func (f pyfuncall) ExportNames() []string {
+	panic("implement me")
+}
+
+func (f pyfuncall) Name() string {
+	return f.name
+}
+
+func (f pyfuncall) DebugName() string {
+	return f.name
+}
+
+func (f pyfuncall) GoFunction() interface{} {
+	return nil
+}
+
+func (f pyfuncall) ParamTypes() []api.ValueType {
+	panic("implement me")
+}
+
+func (f pyfuncall) ParamNames() []string {
+	panic("implement me")
+}
+
+func (f pyfuncall) ResultTypes() []api.ValueType {
+	panic("implement me")
+}
+
+func (f pyfuncall) ResultNames() []string {
+	panic("implement me")
+}
+
+// Return the utf8 encoding of a PyUnicode object. It is a
+// re-implementation of PyUnicode_AsUTF8. The bytes are copied from
+// the vmem, so the returned string is safe to use.
+func pyUnicodeUTf8(m vmem, p ptr32) string {
+	statep := p + padStateInAsciiObject
+	state := deref[uint8](m, statep)
+	compact := state&(1<<5) > 0
+	ascii := state&(1<<6) > 0
+	if !compact || !ascii {
+		panic("only support ascii-compact utf8 representation")
+	}
+
+	length := deref[int32](m, p+padLengthInAsciiObject)
+	bytes := derefArray[byte](m, p+sizeAsciiObject, uint32(length))
+	return unsafe.String(unsafe.SliceData(bytes), len(bytes))
+}
+
+func derefPyUnicodeUtf8(m vmem, p ptr32) string {
+	x := deref[ptr32](m, p)
+	return pyUnicodeUTf8(m, x)
+}
+
+func lineForFrame(m vmem, framep, codep ptr32) int32 {
+	codestart := codep + padCodeAdaptiveInCodeObject
+	previnstr := deref[ptr32](m, framep+padPrevInstrInFrame)
+	firstlineno := deref[int32](m, codep+padFirstlinenoInCodeObject)
+
+	if previnstr < codestart {
+		return firstlineno
+	}
+
+	linearray := deref[ptr32](m, codep+padLinearrayInCodeObject)
+	if linearray != 0 {
+		fmt.Println("LINEARRAY PANIC")
+		panic("can't handle code sections with line arrays")
+	}
+
+	codebytes := deref[ptr32](m, codep+padLinetableInCodeObject)
+	if codebytes == 0 {
+		fmt.Println("CODEBYTES PANIC")
+		panic("code section must have a linetable")
+	}
+
+	length := deref[int32](m, codebytes+padSizeInBytesObject)
+	linetable := codebytes + padSvalInBytesObject
+	addrq := int32(previnstr - codestart)
+
+	lo_next := linetable             // pointer to the current byte in the line table
+	limit := lo_next + ptr32(length) // pointer to the end of the linetable
+	ar_end := int32(0)               // offset into the code section
+	computed_line := firstlineno     // current known line number
+	ar_line := int32(-1)             // line for the current bytecode
+
+	for ar_end <= addrq && lo_next < limit {
+		lineDelta := int32(0)
+		ptr := lo_next
+
+		entry := deref[uint8](m, ptr)
+		code := (entry >> 3) & 15
+		switch code {
+		case enumCodeLocation1:
+			lineDelta = 1
+		case enumCodeLocation2:
+			lineDelta = 2
+		case enumCodeLocationNoCol, enumCodeLocationLong:
+			lineDelta = pysvarint(m, ptr+1)
+		}
+
+		computed_line += lineDelta
+
+		if (entry >> 3) == 0x1F {
+			ar_line = -1
+		} else {
+			ar_line = computed_line
+		}
+
+		ar_end += (int32(entry&7) + 1) * sizeCodeUnit
+
+		lo_next++
+		for lo_next < limit && (deref[uint8](m, lo_next)&128 == 0) {
+			lo_next++
+		}
+	}
+
+	return ar_line
+}
+
+// Python-specific implementation of protobuf signed varints. However
+// it only uses 7 bits, as python uses the most significant bit to
+// store whether an entry starts on that byte.
+func pysvarint(m vmem, p ptr32) int32 {
+	read := deref[uint8](m, p)
+	val := uint32(read & 63)
+	shift := 0
+	for read&64 > 0 {
+		read = deref[uint8](m, p)
+		p++
+		shift += 6
+		val |= uint32(read&63) << shift
+	}
+
+	x := int32(val >> 1)
+	if val&1 > 0 {
+		x = ^x
+	}
+	return x
+}

--- a/python.go
+++ b/python.go
@@ -362,7 +362,7 @@ func pysvarint(m vmem, p ptr32) int32 {
 
 	x := int32(val >> 1)
 	if val&1 > 0 {
-		x = ^x
+		x = -x
 	}
 	return x
 }

--- a/python.go
+++ b/python.go
@@ -196,7 +196,6 @@ func (p *pystackiter) Next() bool {
 	oldframe := p.framep
 	p.framep = deref[ptr32](p.mem, p.framep+padPreviousInFrame)
 	if oldframe == p.framep {
-		fmt.Printf("frame previous field pointer to the same frame: %x", p.framep)
 		p.framep = 0
 		return false
 	}
@@ -339,13 +338,11 @@ func lineForFrame(m vmem, framep, codep ptr32) (int32, bool) {
 
 	linearray := deref[ptr32](m, codep+padLinearrayInCodeObject)
 	if linearray != 0 {
-		fmt.Println("LINEARRAY PANIC")
 		panic("can't handle code sections with line arrays")
 	}
 
 	codebytes := deref[ptr32](m, codep+padLinetableInCodeObject)
 	if codebytes == 0 {
-		fmt.Println("CODEBYTES PANIC")
 		panic("code section must have a linetable")
 	}
 

--- a/testdata/python/simple.py
+++ b/testdata/python/simple.py
@@ -1,0 +1,15 @@
+def a():
+    print("world")
+    d = bytearray(100)
+    print(len(d))
+
+def b():
+    a()
+
+def c():
+    print("hello")
+    b()
+    print("!")
+
+if __name__ == "__main__":
+    c()

--- a/wzprof.go
+++ b/wzprof.go
@@ -77,8 +77,9 @@ func ProfilingFor(wasm []byte) *Profiling {
 	// FIXME: detect python here
 	r.onlyFunctions = map[string]struct{}{
 		// TODO: find the right functions to hook into
-		// "_PyEval_EvalFrameDefault":     {},
-		"_PyEvalFramePushAndInit": {},
+		// "_PyEval_EvalFrameDefault": {},
+		// "_PyEvalFramePushAndInit": {},
+		"PyObject_Vectorcall": {},
 	}
 
 	return r


### PR DESCRIPTION
Draft changes to support stack walking and symbolization for Python guests to provide meaningful profiles for python scripts.

Limitations: only support CPython3.11 (testing against https://github.com/stealthrocket/timecraft/tree/main/python), which is built with debug symbols.

Refs https://github.com/stealthrocket/wzprof/issues/64

### TODO

- [x] Detection of Python.
- [x] Detect and constraint version of Python.
- [x] Basic python stack walking.
- [x] Find the right functions to instrument (`_PyEvalFramePushAndInit`  triggers twice).
- [x] Add module information.
- [x] Memory allocations.
- [x] Tests.
- [x] Update README.

### Stretch

- [ ] Understand what's static vs not to offload symbolization to the background.
- [ ] Look into building offsets from CGO + `#include <Python.h>`.
- [ ] Stack walk C functions and match the two stacks.
- [ ] Add column information.

---

![image](https://github.com/stealthrocket/wzprof/assets/172804/62d3da71-ef62-4931-a1e2-8d615199a37e)

![image](https://github.com/stealthrocket/wzprof/assets/172804/24bfaa09-3fd3-4824-b46a-56003946c1c6)
